### PR TITLE
refactor: remove .unwrap() calls

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -8,7 +8,6 @@ const DEFAULT_CONFIG: &str = ".scrtsync.json";
 /// Synchronize secrets between different sources
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
-
 pub struct Args {
     /// Config file to use for presets
     #[arg(short, long, default_value_t = String::from(DEFAULT_CONFIG))]
@@ -85,9 +84,9 @@ impl Config {
         for (name, preset) in &self.presets {
             // Validate that source URLs are parseable
             url::Url::parse(&preset.from)
-                .with_context(|| format!("Invalid 'from' URL in preset '{}'", name))?;
+                .with_context(|| format!("Invalid `from` URL in preset '{name}'"))?;
             url::Url::parse(&preset.to)
-                .with_context(|| format!("Invalid 'to' URL in preset '{}'", name))?;
+                .with_context(|| format!("Invalid `to` URL in preset '{name}'"))?;
         }
         Ok(())
     }

--- a/src/job/init.rs
+++ b/src/job/init.rs
@@ -16,7 +16,7 @@ impl Job for InitJob {
         if path.exists() {
             return Err(std::io::Error::new(
                 std::io::ErrorKind::AlreadyExists,
-                format!("{} already exists", DEFAULT_FILENAME),
+                format!("{DEFAULT_FILENAME} already exists"),
             )
             .into());
         }


### PR DESCRIPTION
- Add validation for missing or empty hosts in Kubernetes and Vault URLs
- Change Secrets conversion from ByteString to use TryFrom with error context
- Update Vault token lookup to provide clearer errors and trim whitespace
- Add tests for invalid UTF-8 in secret values