### PR TITLE
feat: git-style diffs

### DIFF
--- a/codebook.toml
+++ b/codebook.toml
@@ -1,0 +1,1 @@
+words = ["dotenv"]

--- a/src/job/diff.rs
+++ b/src/job/diff.rs
@@ -8,23 +8,12 @@ const CONTEXT_LINES: usize = 3;
 pub struct DiffJob {
     from: Box<dyn Source>,
     to: Box<dyn Source>,
-    from_uri: String,
     to_uri: String,
 }
 
 impl DiffJob {
-    pub fn new(
-        from: Box<dyn Source>,
-        to: Box<dyn Source>,
-        from_uri: String,
-        to_uri: String,
-    ) -> Self {
-        Self {
-            from,
-            to,
-            from_uri,
-            to_uri,
-        }
+    pub fn new(from: Box<dyn Source>, to: Box<dyn Source>, to_uri: String) -> Self {
+        Self { from, to, to_uri }
     }
 }
 
@@ -53,7 +42,7 @@ impl super::Job for DiffJob {
         let hunks = build_hunks(&diff_lines);
         let printer = DiffPrinter::new();
 
-        printer.print_header(&self.from_uri, &self.to_uri);
+        printer.print_header(&self.to_uri);
         for hunk in &hunks {
             printer.print_hunk_header(hunk);
             for line in &hunk.lines {
@@ -227,13 +216,13 @@ impl DiffPrinter {
         }
     }
 
-    fn print_header(&self, from_uri: &str, to_uri: &str) {
+    fn print_header(&self, uri: &str) {
         if self.use_color {
-            println!("\x1b[1m--- {to_uri} (current)\x1b[0m");
-            println!("\x1b[1m+++ {from_uri} (desired)\x1b[0m");
+            println!("\x1b[1m--- a/{uri}\x1b[0m");
+            println!("\x1b[1m+++ b/{uri}\x1b[0m");
         } else {
-            println!("--- {to_uri} (current)");
-            println!("+++ {from_uri} (desired)");
+            println!("--- a/{uri}");
+            println!("+++ b/{uri}");
         }
     }
 

--- a/src/job/diff.rs
+++ b/src/job/diff.rs
@@ -1,19 +1,235 @@
 use crate::sources::Source;
 use anyhow::{Context, Result};
+use std::collections::BTreeMap;
+use std::io::IsTerminal;
 
-// ANSI color/style escape codes
-const GREEN: &str = "\x1b[32m";
-const RED: &str = "\x1b[31m";
-const RESET: &str = "\x1b[0m";
+const CONTEXT_LINES: usize = 3;
 
 pub struct DiffJob {
     from: Box<dyn Source>,
     to: Box<dyn Source>,
+    from_uri: String,
+    to_uri: String,
 }
 
 impl DiffJob {
-    pub fn new(from: Box<dyn Source>, to: Box<dyn Source>) -> Self {
-        Self { from, to }
+    pub fn new(
+        from: Box<dyn Source>,
+        to: Box<dyn Source>,
+        from_uri: String,
+        to_uri: String,
+    ) -> Self {
+        Self {
+            from,
+            to,
+            from_uri,
+            to_uri,
+        }
+    }
+}
+
+/// Format a key=value pair in dotenv style, matching Secrets::to_writer escaping.
+fn format_entry(key: &str, value: &str) -> String {
+    let escaped = serde_json::to_string(value).unwrap_or_else(|_| value.to_string());
+    format!("{key}={escaped}")
+}
+
+#[derive(Clone, Debug)]
+enum DiffLine {
+    Context(String),
+    Remove(String),
+    Add(String),
+}
+
+fn build_diff_lines(
+    from_map: &BTreeMap<String, String>,
+    to_map: &BTreeMap<String, String>,
+) -> (Vec<DiffLine>, usize, usize, usize) {
+    let mut all_keys: Vec<&String> = from_map.keys().chain(to_map.keys()).collect();
+    all_keys.sort();
+    all_keys.dedup();
+
+    let mut diff_lines = Vec::new();
+    let mut added = 0usize;
+    let mut removed = 0usize;
+    let mut changed = 0usize;
+
+    for key in &all_keys {
+        match (from_map.get(*key), to_map.get(*key)) {
+            (Some(from_val), None) => {
+                diff_lines.push(DiffLine::Add(format_entry(key, from_val)));
+                added += 1;
+            }
+            (None, Some(to_val)) => {
+                diff_lines.push(DiffLine::Remove(format_entry(key, to_val)));
+                removed += 1;
+            }
+            (Some(from_val), Some(to_val)) if from_val != to_val => {
+                diff_lines.push(DiffLine::Remove(format_entry(key, to_val)));
+                diff_lines.push(DiffLine::Add(format_entry(key, from_val)));
+                changed += 1;
+            }
+            (Some(from_val), Some(_)) => {
+                diff_lines.push(DiffLine::Context(format_entry(key, from_val)));
+            }
+            _ => {}
+        }
+    }
+
+    (diff_lines, added, changed, removed)
+}
+
+struct Hunk {
+    old_start: usize,
+    new_start: usize,
+    lines: Vec<DiffLine>,
+}
+
+fn build_hunks(diff_lines: &[DiffLine]) -> Vec<Hunk> {
+    // 1. Find indices of all non-context lines
+    let change_indices: Vec<usize> = diff_lines
+        .iter()
+        .enumerate()
+        .filter(|(_, line)| !matches!(line, DiffLine::Context(_)))
+        .map(|(i, _)| i)
+        .collect();
+
+    if change_indices.is_empty() {
+        return vec![];
+    }
+
+    // 2. Group into hunk ranges
+    let mut hunk_ranges: Vec<(usize, usize)> = vec![];
+    let mut range_start = change_indices[0].saturating_sub(CONTEXT_LINES);
+    let mut range_end = (change_indices[0] + CONTEXT_LINES).min(diff_lines.len() - 1);
+
+    for &idx in &change_indices[1..] {
+        let ctx_start = idx.saturating_sub(CONTEXT_LINES);
+        if ctx_start <= range_end + 1 {
+            range_end = (idx + CONTEXT_LINES).min(diff_lines.len() - 1);
+        } else {
+            hunk_ranges.push((range_start, range_end));
+            range_start = ctx_start;
+            range_end = (idx + CONTEXT_LINES).min(diff_lines.len() - 1);
+        }
+    }
+    hunk_ranges.push((range_start, range_end));
+
+    // 3. Build Hunk structs with correct line numbers
+    let mut hunks = vec![];
+    let mut old_line = 1usize;
+    let mut new_line = 1usize;
+    let mut pos = 0usize;
+
+    for (start, end) in &hunk_ranges {
+        // Advance line counters to `start`
+        for line in diff_lines.iter().take(*start).skip(pos) {
+            match line {
+                DiffLine::Context(_) => {
+                    old_line += 1;
+                    new_line += 1;
+                }
+                DiffLine::Remove(_) => {
+                    old_line += 1;
+                }
+                DiffLine::Add(_) => {
+                    new_line += 1;
+                }
+            }
+        }
+
+        let hunk_old_start = old_line;
+        let hunk_new_start = new_line;
+        let lines: Vec<DiffLine> = diff_lines[*start..=*end].to_vec();
+
+        for line in &lines {
+            match line {
+                DiffLine::Context(_) => {
+                    old_line += 1;
+                    new_line += 1;
+                }
+                DiffLine::Remove(_) => {
+                    old_line += 1;
+                }
+                DiffLine::Add(_) => {
+                    new_line += 1;
+                }
+            }
+        }
+
+        hunks.push(Hunk {
+            old_start: hunk_old_start,
+            new_start: hunk_new_start,
+            lines,
+        });
+
+        pos = end + 1;
+    }
+
+    hunks
+}
+
+struct DiffPrinter {
+    use_color: bool,
+}
+
+impl DiffPrinter {
+    fn new() -> Self {
+        Self {
+            use_color: std::io::stdout().is_terminal(),
+        }
+    }
+
+    fn print_header(&self, from_uri: &str, to_uri: &str) {
+        if self.use_color {
+            println!("\x1b[1m--- {to_uri} (current)\x1b[0m");
+            println!("\x1b[1m+++ {from_uri} (desired)\x1b[0m");
+        } else {
+            println!("--- {to_uri} (current)");
+            println!("+++ {from_uri} (desired)");
+        }
+    }
+
+    fn print_hunk_header(&self, hunk: &Hunk) {
+        let old_count = hunk
+            .lines
+            .iter()
+            .filter(|l| matches!(l, DiffLine::Context(_) | DiffLine::Remove(_)))
+            .count();
+        let new_count = hunk
+            .lines
+            .iter()
+            .filter(|l| matches!(l, DiffLine::Context(_) | DiffLine::Add(_)))
+            .count();
+        let header = format!(
+            "@@ -{},{} +{},{} @@",
+            hunk.old_start, old_count, hunk.new_start, new_count
+        );
+        if self.use_color {
+            println!("\x1b[36m{header}\x1b[0m");
+        } else {
+            println!("{header}");
+        }
+    }
+
+    fn print_line(&self, line: &DiffLine) {
+        match line {
+            DiffLine::Context(text) => println!(" {text}"),
+            DiffLine::Remove(text) => {
+                if self.use_color {
+                    println!("\x1b[31m-{text}\x1b[0m");
+                } else {
+                    println!("-{text}");
+                }
+            }
+            DiffLine::Add(text) => {
+                if self.use_color {
+                    println!("\x1b[32m+{text}\x1b[0m");
+                } else {
+                    println!("+{text}");
+                }
+            }
+        }
     }
 }
 
@@ -32,47 +248,25 @@ impl super::Job for DiffJob {
         let from_map = &from_secrets.content;
         let to_map = &to_secrets.content;
 
-        let mut added = 0usize;
-        let mut removed = 0usize;
-        let mut changed = 0usize;
+        let (diff_lines, added, changed, removed) = build_diff_lines(from_map, to_map);
 
-        // Collect all keys from both maps in sorted order
-        let mut all_keys: Vec<&String> = from_map.keys().chain(to_map.keys()).collect();
-        all_keys.sort();
-        all_keys.dedup();
+        if added == 0 && changed == 0 && removed == 0 {
+            eprintln!("Secrets are in sync.");
+            return Ok(());
+        }
 
-        for key in all_keys {
-            match (from_map.get(key), to_map.get(key)) {
-                // Key only in from_map → added
-                (Some(from_val), None) => {
-                    println!("{GREEN}+ {key}={from_val}{RESET}");
-                    added += 1;
-                }
-                // Key only in to_map → removed
-                (None, Some(to_val)) => {
-                    println!("{RED}- {key}={to_val}{RESET}");
-                    removed += 1;
-                }
-                // Key in both but different values → changed
-                (Some(from_val), Some(to_val)) if from_val != to_val => {
-                    println!("{RED}- {key}={to_val}");
-                    println!("{GREEN}+ {key}={from_val}{RESET}");
-                    changed += 1;
-                }
-                (Some(from_val), Some(to_val)) if from_val == to_val => {
-                    println!("  {key}={from_val}");
-                }
-                // All cases should be covered. (None, None) is impossible
-                // (Some(_), Some(_)) variations are covered above.
-                _ => {}
+        let hunks = build_hunks(&diff_lines);
+        let printer = DiffPrinter::new();
+
+        printer.print_header(&self.from_uri, &self.to_uri);
+        for hunk in &hunks {
+            printer.print_hunk_header(hunk);
+            for line in &hunk.lines {
+                printer.print_line(line);
             }
         }
 
-        if added == 0 && changed == 0 && removed == 0 {
-            println!("Secrets are in sync.");
-        } else {
-            println!("\n{added} added, {changed} changed, {removed} removed");
-        }
+        eprintln!("\n{added} added, {changed} changed, {removed} removed");
 
         Ok(())
     }
@@ -80,6 +274,7 @@ impl super::Job for DiffJob {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
     use crate::secrets::Secrets;
     use std::collections::BTreeMap;
 
@@ -92,95 +287,191 @@ mod tests {
     }
 
     #[test]
-    fn diff_counts_added() {
-        let from = make_secrets(&[("FOO", "1"), ("BAR", "2")]);
-        let to = make_secrets(&[("BAR", "2")]);
-        let from_map = &from.content;
-        let to_map = &to.content;
-
-        let added: usize = from_map.keys().filter(|k| !to_map.contains_key(*k)).count();
-        assert_eq!(added, 1);
-    }
-
-    #[test]
-    fn diff_counts_removed() {
-        let from = make_secrets(&[("BAR", "2")]);
-        let to = make_secrets(&[("FOO", "1"), ("BAR", "2")]);
-        let from_map = &from.content;
-        let to_map = &to.content;
-
-        let removed: usize = to_map.keys().filter(|k| !from_map.contains_key(*k)).count();
-        assert_eq!(removed, 1);
-    }
-
-    #[test]
-    fn diff_counts_changed() {
-        let from = make_secrets(&[("FOO", "new"), ("BAR", "same")]);
-        let to = make_secrets(&[("FOO", "old"), ("BAR", "same")]);
-        let from_map = &from.content;
-        let to_map = &to.content;
-
-        let changed: usize = from_map
-            .keys()
-            .filter(|k| to_map.get(*k).map(|v| *v != from_map[*k]).unwrap_or(false))
-            .count();
-        assert_eq!(changed, 1);
-    }
-
-    #[test]
-    fn diff_in_sync() {
+    fn no_diff_when_in_sync() {
         let from = make_secrets(&[("FOO", "1")]);
         let to = make_secrets(&[("FOO", "1")]);
-        let from_map = &from.content;
-        let to_map = &to.content;
-
-        let diffs: usize = from_map
-            .keys()
-            .filter(|k| to_map.get(*k).map(|v| *v != from_map[*k]).unwrap_or(true))
-            .count()
-            + to_map.keys().filter(|k| !from_map.contains_key(*k)).count();
-        assert_eq!(diffs, 0);
+        let (diff_lines, _, _, _) = build_diff_lines(&from.content, &to.content);
+        let hunks = build_hunks(&diff_lines);
+        assert!(hunks.is_empty());
     }
 
     #[test]
-    fn diff_output_added_shows_value() {
-        let from = make_secrets(&[("FOO", "bar")]);
-        let to = make_secrets(&[]);
-        let from_map = &from.content;
-        let to_map = &to.content;
-
-        let added: usize = from_map.keys().filter(|k| !to_map.contains_key(*k)).count();
-        let changed: usize = from_map
-            .keys()
-            .filter(|k| to_map.get(*k).map(|v| *v != from_map[*k]).unwrap_or(false))
-            .count();
+    fn added_key_shows_plus_line() {
+        let from = make_secrets(&[("BAR", "2"), ("FOO", "1")]);
+        let to = make_secrets(&[("BAR", "2")]);
+        let (diff_lines, added, changed, removed) = build_diff_lines(&from.content, &to.content);
         assert_eq!(added, 1);
         assert_eq!(changed, 0);
+        assert_eq!(removed, 0);
+
+        let hunks = build_hunks(&diff_lines);
+        assert_eq!(hunks.len(), 1);
+        assert!(hunks[0]
+            .lines
+            .iter()
+            .any(|l| matches!(l, DiffLine::Add(s) if s.contains("FOO"))));
     }
 
     #[test]
-    fn diff_output_removed_shows_value() {
-        let from = make_secrets(&[]);
-        let to = make_secrets(&[("FOO", "bar")]);
-        let from_map = &from.content;
-        let to_map = &to.content;
-
-        let removed: usize = to_map.keys().filter(|k| !from_map.contains_key(*k)).count();
+    fn removed_key_shows_minus_line() {
+        let from = make_secrets(&[("BAR", "2")]);
+        let to = make_secrets(&[("BAR", "2"), ("FOO", "1")]);
+        let (diff_lines, added, changed, removed) = build_diff_lines(&from.content, &to.content);
+        assert_eq!(added, 0);
+        assert_eq!(changed, 0);
         assert_eq!(removed, 1);
+
+        let hunks = build_hunks(&diff_lines);
+        assert!(hunks[0]
+            .lines
+            .iter()
+            .any(|l| matches!(l, DiffLine::Remove(s) if s.contains("FOO"))));
     }
 
     #[test]
-    fn diff_output_changed_distinguishes_old_and_new() {
-        let from = make_secrets(&[("FOO", "new_val")]);
-        let to = make_secrets(&[("FOO", "old_val")]);
-        let from_map = &from.content;
-        let to_map = &to.content;
+    fn changed_key_shows_minus_then_plus() {
+        let from = make_secrets(&[("FOO", "new")]);
+        let to = make_secrets(&[("FOO", "old")]);
+        let (diff_lines, added, changed, removed) = build_diff_lines(&from.content, &to.content);
+        assert_eq!(added, 0);
+        assert_eq!(changed, 1);
+        assert_eq!(removed, 0);
 
-        // The changed arm uses `to_val` as old and `from_val` as new.
-        let from_val = from_map.get("FOO").unwrap();
-        let to_val = to_map.get("FOO").unwrap();
-        assert_eq!(from_val, "new_val");
-        assert_eq!(to_val, "old_val");
-        assert_ne!(from_val, to_val);
+        let hunks = build_hunks(&diff_lines);
+        let lines = &hunks[0].lines;
+        let remove_idx = lines
+            .iter()
+            .position(|l| matches!(l, DiffLine::Remove(_)))
+            .unwrap();
+        let add_idx = lines
+            .iter()
+            .position(|l| matches!(l, DiffLine::Add(_)))
+            .unwrap();
+        assert!(
+            remove_idx < add_idx,
+            "Remove line should come before Add line"
+        );
+    }
+
+    #[test]
+    fn values_are_json_escaped() {
+        let from = make_secrets(&[("FOO", "hello \"world\"\nnewline")]);
+        let to = make_secrets(&[]);
+        let (diff_lines, _, _, _) = build_diff_lines(&from.content, &to.content);
+        let hunks = build_hunks(&diff_lines);
+        let add_line = hunks[0]
+            .lines
+            .iter()
+            .find(|l| matches!(l, DiffLine::Add(_)))
+            .unwrap();
+        if let DiffLine::Add(text) = add_line {
+            assert!(text.contains(r#"\"world\""#), "Value should be JSON-escaped");
+            assert!(text.contains(r#"\n"#), "Newlines should be escaped");
+        }
+    }
+
+    #[test]
+    fn context_lines_are_limited() {
+        let pairs_from: Vec<(&str, &str)> = vec![
+            ("A01", "v"),
+            ("A02", "v"),
+            ("A03", "v"),
+            ("A04", "v"),
+            ("A05", "v"),
+            ("A06", "changed"),
+            ("A07", "v"),
+            ("A08", "v"),
+            ("A09", "v"),
+            ("A10", "v"),
+        ];
+        let mut pairs_to = pairs_from.clone();
+        pairs_to[5] = ("A06", "original");
+
+        let from = make_secrets(&pairs_from);
+        let to = make_secrets(&pairs_to);
+        let (diff_lines, _, _, _) = build_diff_lines(&from.content, &to.content);
+        let hunks = build_hunks(&diff_lines);
+
+        assert_eq!(hunks.len(), 1);
+        // Should have at most 3 context before + 2 change lines + 3 context after = 8
+        assert!(hunks[0].lines.len() <= 8);
+    }
+
+    #[test]
+    fn separate_hunks_for_distant_changes() {
+        // Two changes separated by more than 6 unchanged keys should produce 2 hunks
+        let pairs_from: Vec<(&str, &str)> = vec![
+            ("A01", "changed"),
+            ("A02", "v"),
+            ("A03", "v"),
+            ("A04", "v"),
+            ("A05", "v"),
+            ("A06", "v"),
+            ("A07", "v"),
+            ("A08", "v"),
+            ("A09", "v"),
+            ("A10", "changed"),
+        ];
+        let mut pairs_to = pairs_from.clone();
+        pairs_to[0] = ("A01", "original");
+        pairs_to[9] = ("A10", "original");
+
+        let from = make_secrets(&pairs_from);
+        let to = make_secrets(&pairs_to);
+        let (diff_lines, _, _, _) = build_diff_lines(&from.content, &to.content);
+        let hunks = build_hunks(&diff_lines);
+
+        assert_eq!(hunks.len(), 2);
+    }
+
+    #[test]
+    fn adjacent_changes_merge_into_one_hunk() {
+        // Two changes separated by ≤6 unchanged keys should merge into 1 hunk
+        let pairs_from: Vec<(&str, &str)> = vec![
+            ("A01", "changed"),
+            ("A02", "v"),
+            ("A03", "v"),
+            ("A04", "v"),
+            ("A05", "v"),
+            ("A06", "v"),
+            ("A07", "v"),
+            ("A08", "changed"),
+        ];
+        let mut pairs_to = pairs_from.clone();
+        pairs_to[0] = ("A01", "original");
+        pairs_to[7] = ("A08", "original");
+
+        let from = make_secrets(&pairs_from);
+        let to = make_secrets(&pairs_to);
+        let (diff_lines, _, _, _) = build_diff_lines(&from.content, &to.content);
+        let hunks = build_hunks(&diff_lines);
+
+        assert_eq!(hunks.len(), 1);
+    }
+
+    #[test]
+    fn hunk_header_line_numbers_are_correct() {
+        // Single change at position 1 (0-indexed), with 1 context before
+        let from = make_secrets(&[("A", "v"), ("B", "new"), ("C", "v")]);
+        let to = make_secrets(&[("A", "v"), ("B", "old"), ("C", "v")]);
+        let (diff_lines, _, _, _) = build_diff_lines(&from.content, &to.content);
+        let hunks = build_hunks(&diff_lines);
+
+        assert_eq!(hunks.len(), 1);
+        assert_eq!(hunks[0].old_start, 1);
+        assert_eq!(hunks[0].new_start, 1);
+
+        let old_count = hunks[0]
+            .lines
+            .iter()
+            .filter(|l| matches!(l, DiffLine::Context(_) | DiffLine::Remove(_)))
+            .count();
+        let new_count = hunks[0]
+            .lines
+            .iter()
+            .filter(|l| matches!(l, DiffLine::Context(_) | DiffLine::Add(_)))
+            .count();
+        assert_eq!(old_count, 3); // A (ctx) + B old (remove) + C (ctx)
+        assert_eq!(new_count, 3); // A (ctx) + B new (add) + C (ctx)
     }
 }

--- a/src/job/diff.rs
+++ b/src/job/diff.rs
@@ -365,7 +365,10 @@ mod tests {
             .find(|l| matches!(l, DiffLine::Add(_)))
             .unwrap();
         if let DiffLine::Add(text) = add_line {
-            assert!(text.contains(r#"\"world\""#), "Value should be JSON-escaped");
+            assert!(
+                text.contains(r#"\"world\""#),
+                "Value should be JSON-escaped"
+            );
             assert!(text.contains(r#"\n"#), "Newlines should be escaped");
         }
     }

--- a/src/job/diff.rs
+++ b/src/job/diff.rs
@@ -28,6 +28,45 @@ impl DiffJob {
     }
 }
 
+impl super::Job for DiffJob {
+    fn run(&self) -> Result<()> {
+        let from_secrets = self
+            .from
+            .read_secrets()
+            .context("unable to read secrets from source")?;
+
+        let to_secrets = self
+            .to
+            .read_secrets()
+            .context("unable to read secrets from target")?;
+
+        let from_map = &from_secrets.content;
+        let to_map = &to_secrets.content;
+
+        let (diff_lines, added, changed, removed) = build_diff_lines(from_map, to_map);
+
+        if added == 0 && changed == 0 && removed == 0 {
+            eprintln!("Secrets are in sync.");
+            return Ok(());
+        }
+
+        let hunks = build_hunks(&diff_lines);
+        let printer = DiffPrinter::new();
+
+        printer.print_header(&self.from_uri, &self.to_uri);
+        for hunk in &hunks {
+            printer.print_hunk_header(hunk);
+            for line in &hunk.lines {
+                printer.print_line(line);
+            }
+        }
+
+        eprintln!("\n{added} added, {changed} changed, {removed} removed");
+
+        Ok(())
+    }
+}
+
 /// Format a key=value pair in dotenv style, matching Secrets::to_writer escaping.
 fn format_entry(key: &str, value: &str) -> String {
     let escaped = serde_json::to_string(value).unwrap_or_else(|_| value.to_string());
@@ -36,11 +75,17 @@ fn format_entry(key: &str, value: &str) -> String {
 
 #[derive(Clone, Debug)]
 enum DiffLine {
+    /// Unchanged line surrounding a change
     Context(String),
+
+    /// Line that should be removed from the target
     Remove(String),
+
+    /// Line that should be added to the target
     Add(String),
 }
 
+/// Build a list of DiffLine representing the differences between from_map and to_map.
 fn build_diff_lines(
     from_map: &BTreeMap<String, String>,
     to_map: &BTreeMap<String, String>,
@@ -79,6 +124,7 @@ fn build_diff_lines(
     (diff_lines, added, changed, removed)
 }
 
+/// Group DiffLines into hunks with CONTEXT_LINES of unchanged lines around each change.
 struct Hunk {
     old_start: usize,
     new_start: usize,
@@ -169,6 +215,7 @@ fn build_hunks(diff_lines: &[DiffLine]) -> Vec<Hunk> {
     hunks
 }
 
+/// Helper for printing diffs with optional color support.
 struct DiffPrinter {
     use_color: bool,
 }
@@ -230,45 +277,6 @@ impl DiffPrinter {
                 }
             }
         }
-    }
-}
-
-impl super::Job for DiffJob {
-    fn run(&self) -> Result<()> {
-        let from_secrets = self
-            .from
-            .read_secrets()
-            .context("unable to read secrets from source")?;
-
-        let to_secrets = self
-            .to
-            .read_secrets()
-            .context("unable to read secrets from target")?;
-
-        let from_map = &from_secrets.content;
-        let to_map = &to_secrets.content;
-
-        let (diff_lines, added, changed, removed) = build_diff_lines(from_map, to_map);
-
-        if added == 0 && changed == 0 && removed == 0 {
-            eprintln!("Secrets are in sync.");
-            return Ok(());
-        }
-
-        let hunks = build_hunks(&diff_lines);
-        let printer = DiffPrinter::new();
-
-        printer.print_header(&self.from_uri, &self.to_uri);
-        for hunk in &hunks {
-            printer.print_hunk_header(hunk);
-            for line in &hunk.lines {
-                printer.print_line(line);
-            }
-        }
-
-        eprintln!("\n{added} added, {changed} changed, {removed} removed");
-
-        Ok(())
     }
 }
 

--- a/src/job/mod.rs
+++ b/src/job/mod.rs
@@ -36,7 +36,7 @@ pub fn new_job(
             .ok_or(SourceError::NoSourceProvided { field: "to" })?;
         let to_source = <dyn Source>::new(&to_uri)?;
 
-        return Ok(Box::new(diff::DiffJob::new(from_source, to_source)));
+        return Ok(Box::new(diff::DiffJob::new(from_source, to_source, from_uri, to_uri)));
     }
 
     let from = if std::io::stdin().is_terminal() {

--- a/src/job/mod.rs
+++ b/src/job/mod.rs
@@ -36,7 +36,12 @@ pub fn new_job(
             .ok_or(SourceError::NoSourceProvided { field: "to" })?;
         let to_source = <dyn Source>::new(&to_uri)?;
 
-        return Ok(Box::new(diff::DiffJob::new(from_source, to_source, from_uri, to_uri)));
+        return Ok(Box::new(diff::DiffJob::new(
+            from_source,
+            to_source,
+            from_uri,
+            to_uri,
+        )));
     }
 
     let from = if std::io::stdin().is_terminal() {

--- a/src/job/mod.rs
+++ b/src/job/mod.rs
@@ -36,12 +36,7 @@ pub fn new_job(
             .ok_or(SourceError::NoSourceProvided { field: "to" })?;
         let to_source = <dyn Source>::new(&to_uri)?;
 
-        return Ok(Box::new(diff::DiffJob::new(
-            from_source,
-            to_source,
-            from_uri,
-            to_uri,
-        )));
+        return Ok(Box::new(diff::DiffJob::new(from_source, to_source, to_uri)));
     }
 
     let from = if std::io::stdin().is_terminal() {


### PR DESCRIPTION
Diffs are now git-compatible. That means they can be piped into tools that understand them. Example:

```sh
scrtsync --from=file://.one.env --to=file://.two.env --diff | delta -s
```

<img width="991" height="464" alt="Screenshot 2026-03-12 at 11 40 53 AM" src="https://github.com/user-attachments/assets/b5f39623-dd44-42d9-b99f-6a1ed1983401" />