### PR TITLE
fix: escape dollar signs to avoid variable expansion

### DIFF
--- a/src/job/diff.rs
+++ b/src/job/diff.rs
@@ -57,8 +57,11 @@ impl super::Job for DiffJob {
 }
 
 /// Format a key=value pair in dotenv style, matching Secrets::to_writer escaping.
+/// Dollar signs are escaped as `\$` to prevent dotenvy variable substitution.
 fn format_entry(key: &str, value: &str) -> String {
-    let escaped = serde_json::to_string(value).unwrap_or_else(|_| value.to_string());
+    let escaped = serde_json::to_string(value)
+        .unwrap_or_else(|_| value.to_string())
+        .replace('$', "\\$");
     format!("{key}={escaped}")
 }
 
@@ -473,5 +476,28 @@ mod tests {
             .count();
         assert_eq!(old_count, 3); // A (ctx) + B old (remove) + C (ctx)
         assert_eq!(new_count, 3); // A (ctx) + B new (add) + C (ctx)
+    }
+
+    #[test]
+    fn dollar_signs_are_escaped_in_diff() {
+        let from = make_secrets(&[("SECRET", "p@$$word")]);
+        let to = make_secrets(&[]);
+        let (diff_lines, _, _, _) = build_diff_lines(&from.content, &to.content);
+        let hunks = build_hunks(&diff_lines);
+        let add_line = hunks[0]
+            .lines
+            .iter()
+            .find(|l| matches!(l, DiffLine::Add(_)))
+            .unwrap();
+        if let DiffLine::Add(text) = add_line {
+            assert!(
+                text.contains(r#"\$"#),
+                "Dollar signs should be escaped in diff output; got: {text}"
+            );
+            assert!(
+                !text.contains("$$"),
+                "Unescaped double-dollar should not appear in diff output; got: {text}"
+            );
+        }
     }
 }

--- a/src/secrets.rs
+++ b/src/secrets.rs
@@ -48,15 +48,18 @@ impl Secrets {
         Ok(secrets)
     }
 
-    /// Write secrets as dotenv-style `KEY="VALUE"` lines
+    /// Write secrets as dotenv-style `KEY="VALUE"` lines.
+    /// Dollar signs are escaped as `\$` to prevent dotenvy variable substitution.
     pub fn to_writer<T: std::io::Write>(&self, buf: &mut T) -> Result<(), SecretsError> {
         for (key, value) in &self.content {
-            let line = format!(
-                "{}={}\n",
-                key,
-                // JSON-encoding is a convenient way to escape characters.
-                serde_json::to_string(value).map_err(SecretsError::EncodeValue)?
-            );
+            let encoded = serde_json::to_string(value)
+                .map_err(SecretsError::EncodeValue)?
+                // Escape `$` so that dotenvy does not perform variable substitution
+                // when reading the value back. dotenvy recognises `\$` inside
+                // double-quoted strings as a literal dollar sign.
+                .replace('$', "\\$");
+
+            let line = format!("{}={}\n", key, encoded);
 
             buf.write_all(line.as_bytes())
                 .map_err(SecretsError::WriteEntry)?;
@@ -210,5 +213,55 @@ mod tests {
 
         let error_message = result.unwrap_err().to_string();
         assert!(error_message.contains("unable to decode UTF-8 value for key 'invalid'"));
+    }
+
+    #[test]
+    fn dollar_sign_is_escaped_on_write() {
+        let mut map = BTreeMap::new();
+        map.insert("SECRET".to_string(), "p@$$word".to_string());
+        let secrets = Secrets::from(map);
+
+        let mut buf: Vec<u8> = vec![];
+        secrets.to_writer(&mut buf).unwrap();
+        let output = String::from_utf8(buf).unwrap();
+
+        // The dollar signs must be escaped in the written output
+        assert_eq!(output, "SECRET=\"p@\\$\\$word\"\n");
+    }
+
+    #[test]
+    fn dollar_sign_round_trips() {
+        let mut map = BTreeMap::new();
+        map.insert("A".to_string(), "p@$$word".to_string());
+        map.insert("B".to_string(), "$HOME/bin".to_string());
+        map.insert("C".to_string(), "${FOO}bar".to_string());
+        map.insert("D".to_string(), "no dollar here".to_string());
+        let secrets = Secrets::from(map.clone());
+
+        // Write
+        let mut buf: Vec<u8> = vec![];
+        secrets.to_writer(&mut buf).unwrap();
+
+        // Read back
+        let result = Secrets::from_reader(&mut buf.as_slice()).unwrap();
+
+        assert_eq!(result.content, map);
+    }
+
+    #[test]
+    fn existing_escapes_still_round_trip_with_dollar() {
+        // Combining $ with other characters that require escaping
+        let mut map = BTreeMap::new();
+        map.insert(
+            "KEY".to_string(),
+            "say \"$NAME\" and cost $5\nnewline".to_string(),
+        );
+        let secrets = Secrets::from(map.clone());
+
+        let mut buf: Vec<u8> = vec![];
+        secrets.to_writer(&mut buf).unwrap();
+        let result = Secrets::from_reader(&mut buf.as_slice()).unwrap();
+
+        assert_eq!(result.content, map);
     }
 }

--- a/src/sources/k8s.rs
+++ b/src/sources/k8s.rs
@@ -125,19 +125,20 @@ async fn create_or_update_secrets(
         ..K8sSecret::default()
     };
 
-    let existing_secret = api.get_opt(secret_name).await.map_err(K8sSourceError::Api)?;
+    let existing_secret = api
+        .get_opt(secret_name)
+        .await
+        .map_err(K8sSourceError::Api)?;
 
     match existing_secret {
-        Some(_) => {
-            api.replace(secret_name, &PostParams::default(), &payload)
-                .await
-                .map_err(K8sSourceError::Api)?
-        }
-        None => {
-            api.create(&PostParams::default(), &payload)
-                .await
-                .map_err(K8sSourceError::Api)?
-        }
+        Some(_) => api
+            .replace(secret_name, &PostParams::default(), &payload)
+            .await
+            .map_err(K8sSourceError::Api)?,
+        None => api
+            .create(&PostParams::default(), &payload)
+            .await
+            .map_err(K8sSourceError::Api)?,
     };
 
     Ok(())


### PR DESCRIPTION
When writing secrets in dotenv style, they may include a dollar sign. Ie.

```sh
SOME_KEY="pas$word"
```

However, when dotenv-style readers look at this (include our own reader), they see the `$` as an indicator that variable substitution should occur.

The fix here is to apply escaping to dollar signs when writing dotenv-style secrets.

```sh
SOME_KEY="pas\$word"
```
