### PR TITLE
fix: update openssl dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -980,9 +980,9 @@ checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
 name = "openssl"
-version = "0.10.64"
+version = "0.10.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95a0481286a310808298130d22dd1fef0fa571e05a8f44ec801801e84b216b1f"
+checksum = "f38c4372413cdaaf3cc79dd92d29d7d9f5ab09b51b10dded508fb90bb70b9222"
 dependencies = [
  "bitflags 2.5.0",
  "cfg-if",
@@ -1015,9 +1015,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.101"
+version = "0.9.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dda2b0f344e78efc2facf7d195d098df0dd72151b26ab98da807afc26c198dff"
+checksum = "13ce1245cd07fcc4cfdb438f7507b0c7e4f3849a69fd84d52374c66d83741bb6"
 dependencies = [
  "cc",
  "libc",


### PR DESCRIPTION
## Summary
- update `openssl` in `Cargo.lock` from `0.10.64` to `0.10.78`
- update `openssl-sys` in `Cargo.lock` from `0.9.101` to `0.9.114`
- address the repo's rust-openssl security advisories

## Validation
- `cargo check`
- `cargo audit` (openssl advisories cleared)