### PR TITLE
feat: support merging multiple sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ For convenience, you can define presets in a config file and then reference them
 
    ```json
    {
-     "$schema": "https://raw.githubusercontent.com/rmarganti/scrtsync/main/schemas/scrtsync.schema.1.0.0.json",
+     "$schema": "https://raw.githubusercontent.com/rmarganti/scrtsync/main/schemas/scrtsync.schema.1.1.0.json",
      "presets": {
        "pull": {
          "from": [

--- a/README.md
+++ b/README.md
@@ -18,6 +18,18 @@ Sync secrets between [Vault](https://www.vaultproject.io/) and a local `.env`.
 scrtsync --from vault://secrets/you/secret/path --to file://.env
 ```
 
+You can also merge multiple sources into a single destination by passing `--from` more than once:
+
+```sh
+scrtsync \
+  --from file://base.env \
+  --from vault://secrets/you/shared \
+  --from vault://secrets/you/app \
+  --to file://.env
+```
+
+When merging, duplicate keys with the same value are allowed. Duplicate keys with different values cause the sync to fail rather than silently overwriting a secret.
+
 The `--from` and `--to` options can be any of the following:
 
 - `file://<path/to/your.env>` - Any .env file on your local file system.
@@ -38,7 +50,11 @@ For convenience, you can define presets in a config file and then reference them
      "$schema": "https://raw.githubusercontent.com/rmarganti/scrtsync/main/schemas/scrtsync.schema.1.0.0.json",
      "presets": {
        "pull": {
-         "from": "vault://secrets/you/secret/path",
+         "from": [
+           "file://base.env",
+           "vault://secrets/you/shared",
+           "vault://secrets/you/app"
+         ],
          "to": "file://.env"
        },
        "push": {
@@ -51,7 +67,7 @@ For convenience, you can define presets in a config file and then reference them
 
 3. You can now run these presets by referencing them by name. To run the above,
    run either `scrtsync pull` or `scrtsync push`.
-4. You can create and modify as many presets as are appropriate for your project.
+4. You can create and modify as many presets as are appropriate for your project. Preset `from` values may be either a single string or an array of source strings.
 
 ## Options
 

--- a/schemas/scrtsync.schema.1.0.0.json
+++ b/schemas/scrtsync.schema.1.0.0.json
@@ -22,8 +22,19 @@
             "type": "object",
             "properties": {
                 "from": {
-                    "description": "The origin source",
-                    "type": "string"
+                    "description": "The origin source, or sources to merge in order",
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            },
+                            "minItems": 1
+                        }
+                    ]
                 },
                 "to": {
                     "description": "The target source",

--- a/schemas/scrtsync.schema.1.1.0.json
+++ b/schemas/scrtsync.schema.1.1.0.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "$id": "https://raw.githubusercontent.com/rmarganti/scrtsync/main/schemas/scrtsync.schema.1.0.0.json",
+    "$id": "https://raw.githubusercontent.com/rmarganti/scrtsync/main/schemas/scrtsync.schema.1.1.0.json",
     "title": "SecretSync config",
     "description": "A configuration file for SecretSync",
     "type": "object",
@@ -22,8 +22,19 @@
             "type": "object",
             "properties": {
                 "from": {
-                    "description": "The origin source",
-                    "type": "string"
+                    "description": "The origin source, or sources to merge in order",
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            },
+                            "minItems": 1
+                        }
+                    ]
                 },
                 "to": {
                     "description": "The target source",

--- a/src/config.rs
+++ b/src/config.rs
@@ -24,6 +24,9 @@ pub enum ConfigError {
         source: url::ParseError,
     },
 
+    #[error("preset '{0}' must include at least one from source")]
+    EmptyPresetFrom(String),
+
     #[error("preset '{0}' not found in config file")]
     PresetNotFound(String),
 
@@ -39,9 +42,9 @@ pub struct Args {
     #[arg(short, long, default_value_t = String::from(DEFAULT_CONFIG))]
     pub config: String,
 
-    /// From where to pull secrets
-    #[arg(short, long)]
-    pub from: Option<String>,
+    /// From where to pull secrets. May be provided multiple times and will be merged.
+    #[arg(short, long, action = clap::ArgAction::Append)]
+    pub from: Vec<String>,
 
     /// To where to output secrets
     #[arg(short, long)]
@@ -66,7 +69,7 @@ impl Args {
 
         if self.diff {
             // Diff mode: need both sides (preset supplies both, or both --from and --to)
-            let has_from = self.preset.is_some() || self.from.is_some();
+            let has_from = self.preset.is_some() || !self.from.is_empty();
             let has_to = self.preset.is_some() || self.to.is_some();
 
             if !has_from || !has_to {
@@ -74,7 +77,7 @@ impl Args {
             }
         } else {
             // Sync mode: need both sides
-            if self.preset.is_none() && (self.from.is_none() || self.to.is_none()) {
+            if self.preset.is_none() && (self.from.is_empty() || self.to.is_none()) {
                 return Err(ConfigError::MissingArguments);
             }
         }
@@ -90,8 +93,38 @@ pub struct Config {
 
 #[derive(Debug, Deserialize)]
 pub struct PresetConfig {
-    pub from: String,
+    pub from: OneOrMany,
     pub to: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+pub enum OneOrMany {
+    One(String),
+    Many(Vec<String>),
+}
+
+impl OneOrMany {
+    pub fn to_vec(&self) -> Vec<String> {
+        match self {
+            OneOrMany::One(value) => vec![value.clone()],
+            OneOrMany::Many(values) => values.clone(),
+        }
+    }
+
+    fn iter(&self) -> Box<dyn Iterator<Item = &String> + '_> {
+        match self {
+            OneOrMany::One(value) => Box::new(std::iter::once(value)),
+            OneOrMany::Many(values) => Box::new(values.iter()),
+        }
+    }
+
+    fn is_empty(&self) -> bool {
+        match self {
+            OneOrMany::One(_) => false,
+            OneOrMany::Many(values) => values.is_empty(),
+        }
+    }
 }
 
 impl Config {
@@ -118,11 +151,17 @@ impl Config {
 
     fn validate(&self) -> Result<(), ConfigError> {
         for (name, preset) in &self.presets {
-            url::Url::parse(&preset.from).map_err(|source| ConfigError::InvalidPresetUrl {
-                preset: name.clone(),
-                field: "from".to_string(),
-                source,
-            })?;
+            if preset.from.is_empty() {
+                return Err(ConfigError::EmptyPresetFrom(name.clone()));
+            }
+
+            for (idx, from) in preset.from.iter().enumerate() {
+                url::Url::parse(from).map_err(|source| ConfigError::InvalidPresetUrl {
+                    preset: name.clone(),
+                    field: format!("from[{idx}]"),
+                    source,
+                })?;
+            }
             url::Url::parse(&preset.to).map_err(|source| ConfigError::InvalidPresetUrl {
                 preset: name.clone(),
                 field: "to".to_string(),
@@ -130,5 +169,87 @@ impl Config {
             })?;
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn preset_from_accepts_single_string() {
+        let cfg: Config = serde_json::from_str(
+            r#"{
+                "presets": {
+                    "pull": {
+                        "from": "file://a.env",
+                        "to": "file://out.env"
+                    }
+                }
+            }"#,
+        )
+        .unwrap();
+
+        let preset = cfg.presets.get("pull").unwrap();
+        assert_eq!(preset.from.to_vec(), vec!["file://a.env".to_string()]);
+    }
+
+    #[test]
+    fn preset_from_accepts_array() {
+        let cfg: Config = serde_json::from_str(
+            r#"{
+                "presets": {
+                    "pull": {
+                        "from": ["file://a.env", "file://b.env"],
+                        "to": "file://out.env"
+                    }
+                }
+            }"#,
+        )
+        .unwrap();
+
+        let preset = cfg.presets.get("pull").unwrap();
+        assert_eq!(
+            preset.from.to_vec(),
+            vec!["file://a.env".to_string(), "file://b.env".to_string()]
+        );
+    }
+
+    #[test]
+    fn validate_rejects_invalid_url_inside_from_array() {
+        let cfg: Config = serde_json::from_str(
+            r#"{
+                "presets": {
+                    "pull": {
+                        "from": ["file://a.env", "not a url"],
+                        "to": "file://out.env"
+                    }
+                }
+            }"#,
+        )
+        .unwrap();
+
+        let err = cfg.validate().unwrap_err();
+        assert!(err.to_string().contains("invalid `from[1]` URL"));
+    }
+
+    #[test]
+    fn validate_rejects_empty_from_array() {
+        let cfg: Config = serde_json::from_str(
+            r#"{
+                "presets": {
+                    "pull": {
+                        "from": [],
+                        "to": "file://out.env"
+                    }
+                }
+            }"#,
+        )
+        .unwrap();
+
+        let err = cfg.validate().unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("preset 'pull' must include at least one from source"));
     }
 }

--- a/src/job/.scrtsync.default.json
+++ b/src/job/.scrtsync.default.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://raw.githubusercontent.com/rmarganti/scrtsync/main/schemas/scrtsync.schema.1.0.0.json",
+    "$schema": "https://raw.githubusercontent.com/rmarganti/scrtsync/main/schemas/scrtsync.schema.1.1.0.json",
     "presets": {
         "pull": {
             "from": "vault://secret/path/to/your/secrets",

--- a/src/job/diff.rs
+++ b/src/job/diff.rs
@@ -1,4 +1,5 @@
-use crate::sources::Source;
+use super::NamedSource;
+use crate::{secrets::Secrets, sources::Source};
 use anyhow::{Context, Result};
 use std::collections::BTreeMap;
 use std::io::IsTerminal;
@@ -6,23 +7,30 @@ use std::io::IsTerminal;
 const CONTEXT_LINES: usize = 3;
 
 pub struct DiffJob {
-    from: Box<dyn Source>,
+    from: Vec<NamedSource>,
     to: Box<dyn Source>,
     to_uri: String,
 }
 
 impl DiffJob {
-    pub fn new(from: Box<dyn Source>, to: Box<dyn Source>, to_uri: String) -> Self {
+    pub fn new(from: Vec<NamedSource>, to: Box<dyn Source>, to_uri: String) -> Self {
         Self { from, to, to_uri }
     }
 }
 
 impl super::Job for DiffJob {
     fn run(&self) -> Result<()> {
-        let from_secrets = self
-            .from
-            .read_secrets()
-            .context("unable to read secrets from source")?;
+        let mut source_secrets = Vec::with_capacity(self.from.len());
+
+        for (uri, source) in &self.from {
+            let secrets = source
+                .read_secrets()
+                .with_context(|| format!("unable to read secrets from source '{uri}'"))?;
+            source_secrets.push((uri.clone(), secrets));
+        }
+
+        let from_secrets =
+            Secrets::merge_named(source_secrets).context("unable to merge source secrets")?;
 
         let to_secrets = self
             .to

--- a/src/job/mod.rs
+++ b/src/job/mod.rs
@@ -6,13 +6,15 @@ mod diff;
 mod init;
 mod sync;
 
+type NamedSource = (String, Box<dyn Source>);
+
 pub trait Job {
     fn run(&self) -> Result<()>;
 }
 
 pub fn new_job(
     config: &crate::config::Config,
-    from: Option<String>,
+    from: Vec<String>,
     to: Option<String>,
     preset: Option<String>,
     diff: bool,
@@ -26,29 +28,23 @@ pub fn new_job(
     if diff {
         // In diff mode we never read from stdin or write to stdout automatically.
         // Both `from` and `to` are required (enforced by Args::validate).
-        let from_uri = from
-            .or_else(|| preset_cfg.map(|p| p.from.clone()))
-            .ok_or(SourceCreateError::NoSourceProvided { field: "from" })?;
-        let from_source = <dyn Source>::new(&from_uri)?;
+        let from_uris = resolve_from_uris(from, preset_cfg, false)?;
+        let from_sources = build_sources(from_uris)?;
 
         let to_uri = to
             .or_else(|| preset_cfg.map(|p| p.to.clone()))
             .ok_or(SourceCreateError::NoSourceProvided { field: "to" })?;
         let to_source = <dyn Source>::new(&to_uri)?;
 
-        return Ok(Box::new(diff::DiffJob::new(from_source, to_source, to_uri)));
+        return Ok(Box::new(diff::DiffJob::new(
+            from_sources,
+            to_source,
+            to_uri,
+        )));
     }
 
-    let from = if std::io::stdin().is_terminal() {
-        from
-    } else {
-        Some("std://".to_string())
-    };
-
-    let from = from
-        .or_else(|| preset_cfg.map(|p| p.from.clone()))
-        .ok_or(SourceCreateError::NoSourceProvided { field: "from" })?;
-    let from = <dyn Source>::new(&from)?;
+    let from_uris = resolve_from_uris(from, preset_cfg, !std::io::stdin().is_terminal())?;
+    let from_sources = build_sources(from_uris)?;
 
     let to = if std::io::stdout().is_terminal() {
         to
@@ -61,5 +57,38 @@ pub fn new_job(
         .ok_or(SourceCreateError::NoSourceProvided { field: "to" })?;
     let to = <dyn Source>::new(&to)?;
 
-    Ok(Box::new(sync::SyncJob::new(from, to)))
+    Ok(Box::new(sync::SyncJob::new(from_sources, to)))
+}
+
+fn resolve_from_uris(
+    cli_from: Vec<String>,
+    preset_cfg: Option<&crate::config::PresetConfig>,
+    use_stdin: bool,
+) -> Result<Vec<String>, SourceCreateError> {
+    if use_stdin && cli_from.is_empty() {
+        return Ok(vec!["std://".to_string()]);
+    }
+
+    if !cli_from.is_empty() {
+        return Ok(cli_from);
+    }
+
+    let preset_from = preset_cfg
+        .map(|p| p.from.to_vec())
+        .ok_or(SourceCreateError::NoSourceProvided { field: "from" })?;
+
+    if preset_from.is_empty() {
+        return Err(SourceCreateError::NoSourceProvided { field: "from" });
+    }
+
+    Ok(preset_from)
+}
+
+fn build_sources(uris: Vec<String>) -> Result<Vec<NamedSource>, SourceCreateError> {
+    uris.into_iter()
+        .map(|uri| {
+            let source = <dyn Source>::new(&uri)?;
+            Ok((uri, source))
+        })
+        .collect()
 }

--- a/src/job/sync.rs
+++ b/src/job/sync.rs
@@ -1,24 +1,32 @@
-use crate::sources::Source;
+use super::NamedSource;
+use crate::{secrets::Secrets, sources::Source};
 use anyhow::{Context, Result};
 
 pub struct SyncJob {
-    origin: Box<dyn Source>,
+    origins: Vec<NamedSource>,
     target: Box<dyn Source>,
 }
 
 impl SyncJob {
-    pub fn new(origin: Box<dyn Source>, target: Box<dyn Source>) -> Self {
-        Self { origin, target }
+    pub fn new(origins: Vec<NamedSource>, target: Box<dyn Source>) -> Self {
+        Self { origins, target }
     }
 }
 
 impl super::Job for SyncJob {
-    /// Synchronize the secrets from an origin to a target
+    /// Synchronize merged secrets from one or more origins to a target.
     fn run(&self) -> Result<()> {
-        let secrets = self
-            .origin
-            .read_secrets()
-            .context("unable to read secrets from source")?;
+        let mut source_secrets = Vec::with_capacity(self.origins.len());
+
+        for (uri, source) in &self.origins {
+            let secrets = source
+                .read_secrets()
+                .with_context(|| format!("unable to read secrets from source '{uri}'"))?;
+            source_secrets.push((uri.clone(), secrets));
+        }
+
+        let secrets =
+            Secrets::merge_named(source_secrets).context("unable to merge source secrets")?;
 
         self.target
             .write_secrets(&secrets)

--- a/src/secrets.rs
+++ b/src/secrets.rs
@@ -3,6 +3,16 @@ use std::collections::BTreeMap;
 use std::str;
 
 #[derive(Debug, thiserror::Error)]
+pub enum SecretsMergeError {
+    #[error("conflicting value for key '{key}' while merging sources '{first_source}' and '{second_source}'")]
+    Conflict {
+        key: String,
+        first_source: String,
+        second_source: String,
+    },
+}
+
+#[derive(Debug, thiserror::Error)]
 pub enum SecretsError {
     #[error("unable to decode env value")]
     DecodeEnv(#[from] dotenvy::Error),
@@ -59,13 +69,47 @@ impl Secrets {
                 // double-quoted strings as a literal dollar sign.
                 .replace('$', "\\$");
 
-            let line = format!("{}={}\n", key, encoded);
+            let line = format!("{key}={encoded}\n");
 
             buf.write_all(line.as_bytes())
                 .map_err(SecretsError::WriteEntry)?;
         }
 
         Ok(())
+    }
+
+    /// Merge secrets from multiple named sources.
+    ///
+    /// Duplicate keys with identical values are accepted. Duplicate keys with
+    /// different values return an error instead of silently overwriting secrets.
+    pub fn merge_named(sources: Vec<(String, Secrets)>) -> Result<Self, SecretsMergeError> {
+        let mut content = BTreeMap::new();
+        let mut origins = BTreeMap::new();
+
+        for (source_name, secrets) in sources {
+            for (key, value) in secrets.content {
+                match content.get(&key) {
+                    None => {
+                        origins.insert(key.clone(), source_name.clone());
+                        content.insert(key, value);
+                    }
+                    Some(existing) if existing == &value => {}
+                    Some(_) => {
+                        let first_source = origins
+                            .get(&key)
+                            .cloned()
+                            .unwrap_or_else(|| "unknown source".to_string());
+                        return Err(SecretsMergeError::Conflict {
+                            key,
+                            first_source,
+                            second_source: source_name,
+                        });
+                    }
+                }
+            }
+        }
+
+        Ok(Self { content })
     }
 }
 
@@ -263,5 +307,59 @@ mod tests {
         let result = Secrets::from_reader(&mut buf.as_slice()).unwrap();
 
         assert_eq!(result.content, map);
+    }
+
+    #[test]
+    fn merge_named_merges_disjoint_sources() {
+        let mut first = BTreeMap::new();
+        first.insert("A".to_string(), "1".to_string());
+        let mut second = BTreeMap::new();
+        second.insert("B".to_string(), "2".to_string());
+
+        let merged = Secrets::merge_named(vec![
+            ("file://a.env".to_string(), Secrets::from(first)),
+            ("file://b.env".to_string(), Secrets::from(second)),
+        ])
+        .unwrap();
+
+        let mut expected = BTreeMap::new();
+        expected.insert("A".to_string(), "1".to_string());
+        expected.insert("B".to_string(), "2".to_string());
+        assert_eq!(merged.content, expected);
+    }
+
+    #[test]
+    fn merge_named_allows_identical_duplicate_values() {
+        let mut first = BTreeMap::new();
+        first.insert("A".to_string(), "1".to_string());
+        let mut second = BTreeMap::new();
+        second.insert("A".to_string(), "1".to_string());
+
+        let merged = Secrets::merge_named(vec![
+            ("file://a.env".to_string(), Secrets::from(first)),
+            ("file://b.env".to_string(), Secrets::from(second)),
+        ])
+        .unwrap();
+
+        assert_eq!(merged.content.get("A"), Some(&"1".to_string()));
+    }
+
+    #[test]
+    fn merge_named_rejects_conflicting_duplicate_values() {
+        let mut first = BTreeMap::new();
+        first.insert("A".to_string(), "1".to_string());
+        let mut second = BTreeMap::new();
+        second.insert("A".to_string(), "2".to_string());
+
+        let result = Secrets::merge_named(vec![
+            ("file://a.env".to_string(), Secrets::from(first)),
+            ("file://b.env".to_string(), Secrets::from(second)),
+        ]);
+
+        assert!(result.is_err());
+        let message = result.unwrap_err().to_string();
+        assert!(message.contains("conflicting value for key 'A'"));
+        assert!(message.contains("file://a.env"));
+        assert!(message.contains("file://b.env"));
     }
 }


### PR DESCRIPTION
## Summary
- allow repeated `--from` args and preset `from` arrays
- merge secrets from multiple sources before sync or diff
- reject conflicting duplicate keys while allowing identical duplicates
- add config schema `1.1.0` for multi-source presets while preserving `1.0.0`
- update default config schema reference and README documentation

## Validation
- `cargo fmt`
- `cargo test`
- `cargo clippy -- -D warnings`